### PR TITLE
chore: Add code formatting and linting tools (Ruff, djLint, Prettier)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      - id: ruff-check
+        args: [ --fix ]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,22 @@
 repos:
+  # Python formatting with Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.0
     hooks:
       - id: ruff-check
         args: [ --fix ]
       - id: ruff-format
+  
+  # Django template formatting
+  - repo: https://github.com/Riverside-Healthcare/djLint
+    rev: v1.35.2
+    hooks:
+      - id: djlint-reformat-django
+      - id: djlint-django
+  
+  # CSS and JavaScript formatting
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [css, scss, javascript, json]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ known-first-party = ["Kanban"]
 
 [tool.djlint]
 profile = "django"
-ignore = "H031"  # Ignore specific rules if needed
+ignore = "H031,H005,H030"  
 indent = 2
 max_line_length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,31 @@ dependencies = [
     "requests>=2.32.5",
     "jwt>=1.4.0",
 ]
+
+[tool.ruff]
+line-length = 79  # Strict PEP 8, or use 88 for Black compatibility
+target-version = "py311"
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "venv",
+    ".venv",
+    "build",
+    "dist",
+]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors (PEP 8)
+    "W",   # pycodestyle warnings
+    "F",   # Pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+]
+
+ignore = []
+
+[tool.ruff.lint.isort]
+known-first-party = ["Kanban"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "jwt>=1.4.0",
 ]
 
+
 [tool.ruff]
 line-length = 79  # Strict PEP 8, or use 88 for Black compatibility
 target-version = "py311"
@@ -41,3 +42,15 @@ ignore = []
 
 [tool.ruff.lint.isort]
 known-first-party = ["Kanban"]
+
+
+[tool.djlint]
+profile = "django"
+ignore = "H031"  # Ignore specific rules if needed
+indent = 2
+max_line_length = 120
+
+[dependency-groups]
+dev = [
+    "djlint>=1.36.4",
+]


### PR DESCRIPTION
## Summary
This PR sets up automated code formatting and linting for the KanbanApp project using pre-commit hooks to ensure consistent code quality across Python, Django templates, CSS, and JavaScript files.

## Changes Made
- ✅ Configure **Ruff** for Python linting and formatting
  - PEP 8 compliance with 79 character line length
  - Enable pycodestyle, Pyflakes, isort, and bugbear rules
  - Exclude migrations and virtual environment directories
  
- ✅ Configure **djLint** for Django HTML template formatting
  - Auto-format Django templates with proper indentation
  - Ignore H005 (lang attribute) and H030 (meta description) rules
  
- ✅ Configure **Prettier** for CSS and JavaScript formatting
  - Consistent code style for static files
  
- ✅ Set up **pre-commit hooks** to run formatters automatically before each commit

## Configuration Files Modified
- `.pre-commit-config.yaml` - Added hooks for all three formatters
- `pyproject.toml` - Added Ruff and djLint configuration

## Benefits
- Ensures consistent code style across the entire project
- Catches common bugs and code quality issues automatically
- Reduces code review time by standardizing formatting
- Prevents formatting-related merge conflicts

## Testing
Tested all formatters with sample files:
- ✅ Ruff: Formats Python files correctly
- ✅ djLint: Formats Django templates with proper indentation
- ✅ Prettier: Formats CSS and JavaScript files

## How to Use
After merging, developers need to install pre-commit hooks:
